### PR TITLE
Get existing amp state

### DIFF
--- a/lib/external/SparkCommsClass.py
+++ b/lib/external/SparkCommsClass.py
@@ -25,6 +25,16 @@ class SparkComms:
         self.send_it(bytes.fromhex(arg))
 
     def send_state_request(self):
+        # Request the current preset number
+        arg = ("01fe000053fe3c000000000000000000" +
+               "f0010400" + "0210" +
+               "00" + "0000" +
+               "0000000000000000000000000000000000" +
+               "000000000000000000000000000000" +
+               "0000f7")
+        self.send_it(bytes.fromhex(arg))
+
+        # Now request the effects and parameters
         arg = ("01fe000053fe3c000000000000000000" +
                "f0010400" + "0201" +
                "00" + "0100" +

--- a/lib/external/SparkCommsClass.py
+++ b/lib/external/SparkCommsClass.py
@@ -24,6 +24,15 @@ class SparkComms:
                "00000000000000000000000000000000" + "0000f7")
         self.send_it(bytes.fromhex(arg))
 
+    def send_state_request(self):
+        arg = ("01fe000053fe3c000000000000000000" +
+               "f0010400" + "0201" +
+               "00" + "0100" +
+               "0000000000000000000000000000000000" +
+               "000000000000000000000000000000" +
+               "0000f7")
+        self.send_it(bytes.fromhex(arg))
+
     # core function to read a block from serial or bluetooth
 
     def get_block(self):

--- a/lib/external/SparkReaderClass.py
+++ b/lib/external/SparkReaderClass.py
@@ -24,6 +24,7 @@ class SparkReadMessage:
     def __init__(self):
         self.data = b''
         self.message = []
+        self.current_preset = None
 
     def set_message(self, msg):
         self.data = msg
@@ -219,6 +220,11 @@ class SparkReadMessage:
         self.add_str ("NewEffect", effect2)
         self.end_str()
 
+    def read_current_preset_number(self):        
+        # Cache this preset value, apply it to the next inbound Preset message
+        self.read_byte()
+        self.current_preset = self.read_byte()        
+
     def read_hardware_preset (self):
         self.start_str()
         self.read_byte ()
@@ -244,8 +250,15 @@ class SparkReadMessage:
     def read_preset (self):
         self.start_str()
         self.read_byte ()
+
         preset = self.read_byte()
+
+        if self.current_preset != None:
+            preset = self.current_preset
+            self.current_preset = None
+
         self.add_int ("PresetNumber", preset)
+
         uuid = self.read_string ()
         self.add_str ("UUID", uuid)
         name = self.read_string ()
@@ -314,6 +327,8 @@ class SparkReadMessage:
                 self.read_preset()
             elif sub_cmd == 0x06:
                 self.read_effect()
+            elif sub_cmd == 0x10:                
+                self.read_current_preset_number()                
             elif sub_cmd == 0x27:
                 self.read_store_hardware_preset()
             elif sub_cmd == 0x37:

--- a/lib/sparkampserver.py
+++ b/lib/sparkampserver.py
@@ -112,7 +112,7 @@ class SparkAmpServer:
                                {dict_message: msg_connection_failed})
 
     def initialise(self):
-        return self.change_to_preset(0)
+        return self.comms.send_state_request()
 
     def eject(self):
         self.listener.stop()

--- a/lib/sparklistener.py
+++ b/lib/sparklistener.py
@@ -33,6 +33,10 @@ class SparkListener:
                     #Acknowledgement
                     continue
 
+                if self.reader.message[0][0] == 3 and self.reader.message[0][1] == 16:
+                    #Current Preset Notification
+                    continue
+
                 if self.reader.python is None:
                     continue
 


### PR DESCRIPTION
Instead of forcing the Amp to Preset 0 on connection in order to track the state, use Paul Hamshere's latest findings to request the current Preset number and effects and parameters as they are on the amp.